### PR TITLE
Fix 17: `split_string()`

### DIFF
--- a/R/read_spc.R
+++ b/R/read_spc.R
@@ -1027,12 +1027,16 @@ hySpc.testthat::test(read_spc) <- function() {
 ###
 
 split_string <- function(x, separator, trim.blank = TRUE, remove.empty = TRUE) {
+
+  stopifnot(length(x) == 1) # we want a single character string
+
   pos <- gregexpr(separator, x)
-  if (length(pos) == 1 && pos[[1]] == -1) {
+  pos <- pos[[1]]
+
+  if (length(pos) == 1 & pos[1] == -1) { # -1 means no match
     return(x)
   }
 
-  pos <- pos[[1]]
 
   pos <- matrix(c(
     1, pos + attr(pos, "match.length"),

--- a/R/read_spc.R
+++ b/R/read_spc.R
@@ -1026,7 +1026,7 @@ hySpc.testthat::test(read_spc) <- function() {
 ###
 ###
 
-split_string <- function(x, separator, trim.blank = TRUE, remove.empty = TRUE) {
+split_string <- function(x, separator, trim_blank = TRUE, remove_empty = TRUE) {
 
   stopifnot(length(x) == 1) # we want a single character string
 
@@ -1051,12 +1051,12 @@ split_string <- function(x, separator, trim.blank = TRUE, remove.empty = TRUE) {
 
   x <- apply(pos, 1, function(p, x) substr(x, p[1], p[2]), x)
 
-  if (trim.blank) {
-    blank.pattern <- "^[[:blank:]]*([^[:blank:]]+.*[^[:blank:]]+)[[:blank:]]*$"
-    x <- sub(blank.pattern, "\\1", x)
+  if (trim_blank) {
+    blank_pattern <- "^[[:blank:]]*([^[:blank:]]+.*[^[:blank:]]+)[[:blank:]]*$"
+    x <- sub(blank_pattern, "\\1", x)
   }
 
-  if (remove.empty) {
+  if (remove_empty) {
     x <- x[sapply(x, nchar) > 0]
   }
 
@@ -1065,16 +1065,16 @@ split_string <- function(x, separator, trim.blank = TRUE, remove.empty = TRUE) {
 
 ### split_line
 
-split_line <- function(x, separator, trim.blank = TRUE) {
+split_line <- function(x, separator, trim_blank = TRUE) {
   tmp <- regexpr(separator, x)
 
   key <- substr(x, 1, tmp - 1)
   value <- substr(x, tmp + 1, nchar(x))
 
-  if (trim.blank) {
-    blank.pattern <- "^[[:blank:]]*([^[:blank:]]+.*[^[:blank:]]+)[[:blank:]]*$"
-    key <- sub(blank.pattern, "\\1", key)
-    value <- sub(blank.pattern, "\\1", value)
+  if (trim_blank) {
+    blank_pattern <- "^[[:blank:]]*([^[:blank:]]+.*[^[:blank:]]+)[[:blank:]]*$"
+    key <- sub(blank_pattern, "\\1", key)
+    value <- sub(blank_pattern, "\\1", value)
   }
 
   value <- as.list(value)


### PR DESCRIPTION
- Fixes #17 

Logic was corrected by @cbeleites in https://github.com/r-hyperspec/hyperSpec/commit/dbbad96b7d0c52f73996639e75feace2951458bf

***
Instead of throwing error:
```
Warning message:
In length(pos) == 1 && pos[[1]] == -1 :
  'length(x) = 11 > 1' in coercion to 'logical(1)'
```

Gives a correct result:

``` r
y <- 
  hySpc.read.spc::read_spc(
    filename = system.file("extdata/1.spc", package = "ir"),
    log_txt = TRUE,
    log_bin = TRUE,
    log_disk = TRUE,
    keys_hdr2data = TRUE,
    keys_log2data = TRUE,
    no_object = FALSE
  )
hyperSpec::plot(y)
```

![](https://i.imgur.com/2f04fMq.png)

<sup>Created on 2022-07-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>



